### PR TITLE
Add ability to pass data along with the login confirmation event

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ of every HTTP 401 response is buffered and everytime it happens, the
 'event:auth-loginRequired' message is broadcasted from $rootScope.
 
 The 'authService' has only one method: #loginConfirmed().
-You are responsible to invoke this method after user logged in.
-It will retry all the requests previously failed due to HTTP 401 response.
+You are responsible to invoke this method after user logged in. You may optionally pass in 
+a data argument to the loginConfirmed method which will be passed on to the loginConfirmed
+$broadcast. This may be useful, for example if you need to pass through details of the user 
+that was logged in. The 'authService' will then retry all the requests previously failed due 
+to HTTP 401 response.
 
 ###Typical use case:
 

--- a/src/angular-http-auth.js
+++ b/src/angular-http-auth.js
@@ -84,6 +84,12 @@ angular.module('http-auth-interceptor', [])
       }
 
       return {
+        /**
+        * call this function to indicate that authentication was successfull and trigger a 
+        * retry of all deferred requests.
+        * Function accepts a data argument to pass on to $broadcast which may be useful for
+        * example if you need to pass through details of the user that was logged in
+        */
         loginConfirmed: function (data) {
           $rootScope.$broadcast('event:auth-loginConfirmed', data);
           retryAll();


### PR DESCRIPTION
This is quite useful if you want to listen out for login confirmation
and have access to _who_ logged in (for presentation purposes)
