### PR TITLE
Prevent unbuffered responses from being deferred.

### DIFF
--- a/src/angular-http-auth.js
+++ b/src/angular-http-auth.js
@@ -105,14 +105,13 @@ angular.module('http-auth-interceptor', [])
 
       function error(response) {
         if (response.status === 401) {
-          var deferred = $q.defer();
-
           if (!authServiceProvider.shouldIgnoreUrl(response)) {
+            var deferred = $q.defer();
             authServiceProvider.pushToBuffer(response.config, deferred);
+            return deferred.promise;
           }
 
           $rootScope.$broadcast('event:auth-loginRequired');
-          return deferred.promise;
         }
         // otherwise
         return $q.reject(response);


### PR DESCRIPTION
401 responses matching the shouldIgnoreURL criteria will not be buffered
and as such they should be be returned as a deferred promise but rather
they should be rejected.

By rejecting instead of deferring we allow the client to properly detect
failed login attempts in the login form. e.g. 401 from /api/auth
properly returns a 401 immediately upon improper credentials.
