### PR TITLE
403/forbidden and cancelling

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -18,7 +18,7 @@
        * @param data an optional argument to pass on to $broadcast which may be useful for
        * example if you need to pass through details of the user that was logged in
        */
-      confirmLogin: function(data) {
+      loginConfirmed: function(data) {
         $rootScope.$broadcast('event:auth-loginConfirmed', data);
         httpBuffer.retryAll();
       },
@@ -28,8 +28,8 @@
        * All deferred requests will be cancelled.
        * @param data an optional argument to pass on to $broadcast.
        */
-      cancelLogin: function(data) {
-        httpBuffer.clearAll();
+      loginCancelled: function(data) {
+        httpBuffer.rejectAll();
         $rootScope.$broadcast('event:auth-loginCancelled', data);
       }
     };
@@ -120,10 +120,10 @@
        * anything deferred shouldn't happen, so reject it
        * and clear the buffer
        */
-      clearAll: function() {
+      rejectAll: function() {
         for (var i =0; i < buffer.length; i++) {
           try {
-            buffer[i].deferred.reject();
+            buffer[i].deferred.reject('[http-auth-cancelled]');
           }
           catch (err) {
           }


### PR DESCRIPTION
This change adds support for 403/forbidden.  It adds response.data to allow the backend to indicate reasons for 403s (and theoretically for 401s though that doesn't make as much sense).

It also renames the loginConfirmed function to confirmLogin to make it clearer that you are indicating confirmation to the service and adds cancelLogin.  cancelLogin clears the buffer so that requests aren't stacked up if the user doesn't log in.

I have a pull request for the gh-pages that hacks up the demo app to demonstrate these features.  I'll make a pull request for that as well, though you may not want to pull it in en-masse because I was somewhat sloppy with the HTML/CSS since I don't do photoshop.  Also, I forgot to edit the readme file but I imagine that if you want to merge this you'd like to do the documentation yourself, anyway.

Thanks -- this is a great little component!
