### PR TITLE
Add function to update retried request configs

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -7,36 +7,37 @@
  */
 (function () {
   'use strict';
-  
+
   angular.module('http-auth-interceptor', ['http-auth-interceptor-buffer'])
 
   .factory('authService', ['$rootScope','httpBuffer', function($rootScope, httpBuffer) {
     return {
       /**
-       * call this function to indicate that authentication was successfull and trigger a 
+       * call this function to indicate that authentication was successfull and trigger a
        * retry of all deferred requests.
        * @param data an optional argument to pass on to $broadcast which may be useful for
        * example if you need to pass through details of the user that was logged in
        */
-      loginConfirmed: function(data) {
+      loginConfirmed: function(data, configUpdater) {
+        var updater = configUpdater || function(config) {return config;};
         $rootScope.$broadcast('event:auth-loginConfirmed', data);
-        httpBuffer.retryAll();
+        httpBuffer.retryAll(updater);
       }
     };
   }])
 
   /**
    * $http interceptor.
-   * On 401 response (without 'ignoreAuthModule' option) stores the request 
+   * On 401 response (without 'ignoreAuthModule' option) stores the request
    * and broadcasts 'event:angular-auth-loginRequired'.
    */
   .config(['$httpProvider', function($httpProvider) {
-    
+
     var interceptor = ['$rootScope', '$q', 'httpBuffer', function($rootScope, $q, httpBuffer) {
       function success(response) {
         return response;
       }
- 
+
       function error(response) {
         if (response.status === 401 && !response.config.ignoreAuthModule) {
           var deferred = $q.defer();
@@ -47,15 +48,15 @@
         // otherwise, default behaviour
         return $q.reject(response);
       }
- 
+
       return function(promise) {
         return promise.then(success, error);
       };
- 
+
     }];
     $httpProvider.responseInterceptors.push(interceptor);
   }]);
-  
+
   /**
    * Private module, a utility, required internally by 'http-auth-interceptor'.
    */
@@ -64,10 +65,10 @@
   .factory('httpBuffer', ['$injector', function($injector) {
     /** Holds all the requests, so they can be re-requested in future. */
     var buffer = [];
-    
+
     /** Service initialized later because of circular dependency problem. */
-    var $http; 
-    
+    var $http;
+
     function retryHttpRequest(config, deferred) {
       function successCallback(response) {
         deferred.resolve(response);
@@ -78,24 +79,24 @@
       $http = $http || $injector.get('$http');
       $http(config).then(successCallback, errorCallback);
     }
-    
+
     return {
       /**
        * Appends HTTP request configuration object with deferred response attached to buffer.
        */
       append: function(config, deferred) {
         buffer.push({
-          config: config, 
+          config: config,
           deferred: deferred
-        });      
+        });
       },
-              
+
       /**
        * Retries all the buffered requests clears the buffer.
        */
-      retryAll: function() {
+      retryAll: function(updater) {
         for (var i = 0; i < buffer.length; ++i) {
-          retryHttpRequest(buffer[i].config, buffer[i].deferred);
+          retryHttpRequest(updater(buffer[i].config), buffer[i].deferred);
         }
         buffer = [];
       }


### PR DESCRIPTION
I've added a function to update configs of retried requests, similar to #31 but a little nicer in that it won't break backwards compatability or break if the function isn't specified.
