### PR TITLE
interceptor: broadcast `response.config` with `loginRequired`.

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -42,7 +42,7 @@
         if (response.status === 401 && !response.config.ignoreAuthModule) {
           var deferred = $q.defer();
           httpBuffer.append(response.config, deferred);
-          $rootScope.$broadcast('event:auth-loginRequired', response.config);
+          $rootScope.$broadcast('event:auth-loginRequired', response);
           return deferred.promise;
         }
         // otherwise, default behaviour


### PR DESCRIPTION
May generally be useful to know information about the unauthorized request when handling it.

My use case is picking out pre-filled-in login/signup data from the request data/params.
