### PR TITLE
Enable JSONP monitoring.

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -35,6 +35,12 @@
 
     var interceptor = ['$rootScope', '$q', 'httpBuffer', function($rootScope, $q, httpBuffer) {
       function success(response) {
+        if (response.config.method == 'JSONP' && response.data.statusCode === 401) {
+          var deferred = $q.defer();
+          httpBuffer.append(response.config, deferred);
+          $rootScope.$broadcast('event:auth-loginRequired');
+          return deferred.promise;
+        }
         return response;
       }
 


### PR DESCRIPTION
Allows to trigger an `event:auth-loginRequired` when the server returns a statusCode field with value 401 in a JSON-P response.
