### PR TITLE
Revert to old array iteration

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -107,7 +107,7 @@
        */
       rejectAll: function(reason) {
         if (reason) {
-          for (var i in buffer) {
+          for (var i = 0, bufferLength = buffer.length; i < bufferLength ; ++i) {
             buffer[i].deferred.reject(reason);
           }
         }
@@ -118,7 +118,7 @@
        * Retries all the buffered requests clears the buffer.
        */
       retryAll: function(updater) {
-        for (var i in buffer) {
+        for (var i = 0, bufferLength = buffer.length; i < bufferLength ; ++i) {
           retryHttpRequest(updater(buffer[i].config), buffer[i].deferred);
         }
         buffer = [];


### PR DESCRIPTION
In order to be compatible with old versions of Internet Explorer.

`for (var i in ...)` doesn't work on IE < 9...
