### PR TITLE
Broadcast event:auth-loginRequired earlier

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -91,7 +91,6 @@
        * Appends HTTP request configuration object with deferred response attached to buffer.
        */
       append: function(config, deferred) {
-        debugger;
         buffer.push({
           config: config,
           deferred: deferred


### PR DESCRIPTION
The API I am working with returns a 401 status for failed login attempts. This is causing a problem when the user gets prompted to login, types an invalid username and password, the failed login attempt gets pushed onto the httpBuffer to be retried later. Then when the user enters a valid username and password the invlalid attempt is retried, which produces a 401 from the api pushing them back to the login screen.

My solution is to just broadcast the 'event:auth-loginRequired' event before checking if rejection.config.ingoreAuthModule is set to true. This will give the developer a chance to set rejection.config.ignoreAuthModule to true in their event handler should they so choose to not have the failed request pushed on to the httpBuffer.
