### PR TITLE
Add dont retry option

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -48,7 +48,7 @@
         responseError: function(rejection) {
           if (rejection.status === 401 && !rejection.config.ignoreAuthModule) {
             var deferred = $q.defer();
-            if (!rejection.config.retryAuthModule) {
+            if (!rejection.config.dontRetry) {
               httpBuffer.append(rejection.config, deferred);
             }
             $rootScope.$broadcast('event:auth-loginRequired', rejection);


### PR DESCRIPTION
I have a situation where I want an http request to trigger the login page on 401, but I don't want it to be retried. Adding this check will allow someone to write `$http({... , dontRetry: true})`
