### PR TITLE
Use confirmLogin and cancelLogin from broadcasted event rather than depending on a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-HTTP Auth Interceptor Module
-============================
-for AngularJS
--------------
+# HTTP Auth Interceptor Module
+
+##for AngularJS
 
 This is the implementation of the concept described in
 [Authentication in AngularJS (or similar) based application](http://www.espeo.pl/2012/02/26/authentication-in-angularjs-application).
@@ -13,37 +12,60 @@ Launch demo [here](http://witoldsz.github.com/angular-http-auth/)
 or switch to [gh-pages](https://github.com/witoldsz/angular-http-auth/tree/gh-pages)
 branch for source code of the demo.
 
-Manual
-------
+## Manual
 
-This module installs $http interceptor and provides the `authService`.
+This module installs an $http interceptor.
 
 The $http interceptor does the following:
 the configuration object (this is the requested URL, payload and parameters)
 of every HTTP 401 response is buffered and everytime it happens, the
-`event:auth-loginRequired` message is broadcasted from $rootScope.
+`event:auth-loginRequired` message is broadcasted from $rootScope. The argument of that message contains three fields:
 
-The `authService` has only one method: #loginConfirmed().
-You are responsible to invoke this method after user logged in. You may optionally pass in
-a data argument to the loginConfirmed method which will be passed on to the loginConfirmed
-$broadcast. This may be useful, for example if you need to pass through details of the user
-that was logged in. The `authService` will then retry all the requests previously failed due
-to HTTP 401 response.
+* `rejection`: The original argument from AngularJS
+* `confirmLogin`: The function to call to retry all previously failed requests due to HTTP 401
+* `cancelLogin`: Empties the requests buffer
 
-###Typical use case:
+You are responsible to invoke the `confirmLogin` method after the user logged in; then all requests previously failed due to a HTTP 401 response will be retried.
+
+You can also call the `cancelLogin` method to clear the requests buffer, as an example if the user decides to cancel the login.
+
+Here are the events that can be broadcasted by angular-http-auth:
+
+* `event:auth-loginRequired`: Fired whenever an HTTP 401 response occurs. The argument contains the methods required to confirm or cancel the login (`confirmLogin` and `cancelLogin`)
+* `event:auth-loginConfirmed`: Fired after `confirmLogin` has been called.
+* `event:auth-loginCancelled`: Fired after `cancelLogin` has been called.
+
+### Example:
+
+Here is a simple example where myLoginService.promptLogin() is a custom service that shows a modal window and returns a promise.
+
+```javascript
+$scope.$on('event:auth-loginRequired', function(e, args) {
+	myLoginService.promptLogin().then(
+		function() {
+			args.confirmLogin();
+		},
+		function() {
+			args.cancelLogin();
+		});
+});
+```
+
+### Typical use case:
 
 * somewhere (some service or controller) the: `$http(...).then(function(response) { do-something-with-response })` is invoked,
 * the response of that requests is a **HTTP 401**,
 * `http-auth-interceptor` captures the initial request and broadcasts `event:auth-loginRequired`,
 * your application intercepts this to e.g. show a login dialog:
  * DO NOT REDIRECT anywhere (you can hide your forms), just show login dialog
-* once your application figures out the authentication is OK, call: `authService.loginConfirmed()`,
+* once your application figures out the authentication is OK, call: `args.confirmLogin()`,
 * your initial failed request will now be retried and when proper response is finally received,
 the `function(response) {do-something-with-response}` will fire,
 * your application will continue as nothing had happened.
 
-###Advanced use case:
-Same beginning as before but,
-* once your application figures out the authentication is OK, call: `authService.loginConfirmed([data], [updateConfigFunc])`,
-* your initial failed request will now be retried but you can supply additional data to observers who are listening for `event:auth-loginConfirmed`, and all your queued http requests will be recalculated by your `updateConfigFunc(httpConfig)` function. This is very usefull if you need to update the headers with new credentials and/or tokens from your successful login.
+### Advanced use case:
 
+Same beginning as before but;
+
+* once your application figures out the authentication is OK, call: `args.confirmLogin([data], [updateConfigFunc])`,
+* your initial failed request will now be retried but you can supply additional data to observers who are listening for `event:auth-loginConfirmed`, and all your queued http requests will be recalculated by your `updateConfigFunc(httpConfig)` function. This is very useful if you need to update the headers with new credentials and/or tokens from your successful login.

--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -10,33 +10,6 @@
 
   angular.module('http-auth-interceptor', ['http-auth-interceptor-buffer'])
 
-  .factory('authService', ['$rootScope','httpBuffer', function($rootScope, httpBuffer) {
-    return {
-      /**
-       * Call this function to indicate that authentication was successfull and trigger a
-       * retry of all deferred requests.
-       * @param data an optional argument to pass on to $broadcast which may be useful for
-       * example if you need to pass through details of the user that was logged in
-       */
-      loginConfirmed: function(data, configUpdater) {
-        var updater = configUpdater || function(config) {return config;};
-        $rootScope.$broadcast('event:auth-loginConfirmed', data);
-        httpBuffer.retryAll(updater);
-      },
-
-      /**
-       * Call this function to indicate that authentication should not proceed.
-       * All deferred requests will be abandoned or rejected (if reason is provided).
-       * @param data an optional argument to pass on to $broadcast.
-       * @param reason if provided, the requests are rejected; abandoned otherwise.
-       */
-      loginCancelled: function(data, reason) {
-        httpBuffer.rejectAll(reason);
-        $rootScope.$broadcast('event:auth-loginCancelled', data);
-      }
-    };
-  }])
-
   /**
    * $http interceptor.
    * On 401 response (without 'ignoreAuthModule' option) stores the request
@@ -44,12 +17,40 @@
    */
   .config(['$httpProvider', function($httpProvider) {
     $httpProvider.interceptors.push(['$rootScope', '$q', 'httpBuffer', function($rootScope, $q, httpBuffer) {
-      return {
+
+      /**
+       * Call this function to indicate that authentication was successfull and trigger a
+       * retry of all deferred requests.
+       * @param data an optional argument to pass on to $broadcast which may be useful for
+       * example if you need to pass through details of the user that was logged in
+       */
+      function loginConfirmed(data, configUpdater) {
+        var updater = configUpdater || function(config) {return config;};
+        $rootScope.$broadcast('event:auth-loginConfirmed', data);
+        httpBuffer.retryAll(updater);
+      }
+
+      /**
+       * Call this function to indicate that authentication should not proceed.
+       * All deferred requests will be abandoned or rejected (if reason is provided).
+       * @param data an optional argument to pass on to $broadcast.
+       * @param reason if provided, the requests are rejected; abandoned otherwise.
+       */
+      function cancelLogin(data, reason) {
+        httpBuffer.rejectAll(reason);
+        $rootScope.$broadcast('event:auth-loginCancelled', data);
+      }
+      
+	  return {
         responseError: function(rejection) {
           if (rejection.status === 401 && !rejection.config.ignoreAuthModule) {
             var deferred = $q.defer();
             httpBuffer.append(rejection.config, deferred);
-            $rootScope.$broadcast('event:auth-loginRequired', rejection);
+            $rootScope.$broadcast('event:auth-loginRequired', {
+              rejection: rejection,
+              confirmLogin: loginConfirmed,
+              cancelLogin: cancelLogin
+            });
             return deferred.promise;
           }
           // otherwise, default behaviour


### PR DESCRIPTION
Hi!

Here's the pull request for issue #57; I put together an implementation with as few changes and bells and whistles as possible. Let me know what you think. I also updated the README.md file, though again I didn't want to rewrite what didn't need to. It might be worth it though.

One last comment; I encourage you to use grunt or gulp to run jshint and maybe a few unit tests; it makes it easier to ensure someone doesn't break anything :)

Here is a simple example where myLoginService.promptLogin() is a custom service that shows a modal window and returns a promise.

``` javascript
$scope.$on('event:auth-loginRequired', function(e, args) {
    myLoginService.promptLogin().then(
        function() {
            args.confirmLogin();
        },
        function() {
            args.cancelLogin();
        });
});
```

I'll let you (or someone else) peer review the commit, especially the function names and event names. Since we're breaking backward compatibility, it would be a good timing to review them :) Let me know what you think!
