### PR TITLE
adding 403 as possible response code to trigger a loginRequired event

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -46,7 +46,7 @@
     $httpProvider.interceptors.push(['$rootScope', '$q', 'httpBuffer', function($rootScope, $q, httpBuffer) {
       return {
         responseError: function(rejection) {
-          if (rejection.status === 401 && !rejection.config.ignoreAuthModule) {
+          if ((rejection.status === 401 || rejection.status === 403) && !rejection.config.ignoreAuthModule) {
             var deferred = $q.defer();
             httpBuffer.append(rejection.config, deferred);
             $rootScope.$broadcast('event:auth-loginRequired', rejection);


### PR DESCRIPTION
the HTTP spec does not specify 403 as a valid response code for requests that require authentication, but the Django server (and maybe others?) sends 403 for requests that failed because the user was not authenticated
