### PR TITLE
Edited Interceptor for 401

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -57,7 +57,8 @@
                 var deferred = $q.defer();
                 httpBuffer.append(rejection.config, deferred);
                 $rootScope.$broadcast('event:auth-loginRequired', rejection);
-                return deferred.promise;
+                // return deferred.promise;
+                return $q.reject(rejection); //why prevent the default behavior?
               case 403:
                 $rootScope.$broadcast('event:auth-forbidden', rejection);
                 break;


### PR DESCRIPTION
Why prevent the default behavior when a 401 is intercepted? This made me going crazy for quite 2 hours.
