### PR TITLE
Update version to match current release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "author": "Witold Szczerba",
   "name": "angular-http-auth",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/witoldsz/angular-http-auth",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The currently released tag is `1.2.2` however the bower.json in the release indicates version `1.2.1`.

This generates warnings during a bower install.
```
bower angular-http-auth#~1.2.2         mismatch Version declared in the json (1.2.1) is different than the resolved one (1.2.2)
```