### PR TITLE
Added ignoreAuthBuffer configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 node_modules
 bower_components
 components
+
+.idea/.name
+
+.idea/angular-http-auth.iml
+
+.idea/encodings.xml
+
+.idea/modules.xml
+
+.idea/scopes/scope_settings.xml
+
+.idea/vcs.xml
+
+.idea/workspace.xml

--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -17,7 +17,7 @@
        * retry of all deferred requests.
        * @param data an optional argument to pass on to $broadcast which may be useful for
        * example if you need to pass through details of the user that was logged in
-       * @param configUpdater an optional transformation function that can modify the                                                                                                                                                   
+       * @param configUpdater an optional transformation function that can modify the
        * requests that are retried after having logged in.  This can be used for example
        * to add an authentication token.  It must return the request.
        */
@@ -55,7 +55,8 @@
             switch (rejection.status) {
               case 401:
                 var deferred = $q.defer();
-                httpBuffer.append(rejection.config, deferred);
+                  if (!rejection.config.ignoreAuthBuffer)
+                      httpBuffer.append(rejection.config, deferred);
                 $rootScope.$broadcast('event:auth-loginRequired', rejection);
                 return deferred.promise;
               case 403:


### PR DESCRIPTION
ignoreAuthBuffer configuration allows a request to modify buffering of
the request on failure. This is particularly useful for handling
application logout in SPAs. The server returns a 401 for logout
requests and this should not be buffered as buffering will mean the
user will be logged out again on successful login. ignoreAuthModule is not sufficient 
here as the 401 request must be captured to render the login page. The logout 
request however must not be buffered