### PR TITLE
Install via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "angular-http-auth",
+  "version": "1.2.2",
+  "description": "HTTP Auth Interceptor Module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/witoldsz/angular-http-auth.git"
+  },
+  "keywords": [
+    "angular",
+    "auth"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/witoldsz/angular-http-auth"
+}


### PR DESCRIPTION
I tend not to use Bower any more since 99% of JS libs have a `package.json` and hence can be installed directly from GitHub using `npm`.