### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "author": "Witold Szczerba",
   "name": "angular-http-auth",
-  "version": "1.2.2",
   "homepage": "https://github.com/witoldsz/angular-http-auth",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property