### PR TITLE
use the config for the next requests (+ cookies)

### DIFF
--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -82,7 +82,7 @@
           return $q.reject(rejection);
         },
 		request : function(config) {
-			angular.extend(config, authConfigService.config);
+			angular.merge(config, authConfigService.config);
 			return config;
 	    }
       };

--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -60,6 +60,9 @@
    * and broadcasts 'event:auth-forbidden'.
    */
   .config(['$httpProvider', function($httpProvider) {
+
+    $httpProvider.defaults.withCredentials = true;
+
     $httpProvider.interceptors.push(['$rootScope', '$q', 'httpBuffer', 'authConfigService', function($rootScope, $q, httpBuffer, authConfigService) {
       return {
         responseError: function(rejection) {


### PR DESCRIPTION
For the issue #108 .

I just added a new service for holding the config and then added a request handler on the http interceptor to read the config and send it with every request.

An update from #109 that I closed, because angular was not sending the cookies anymore...