### PR TITLE
Add missing ignore to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,5 +9,8 @@
   "main": "./src/http-auth-interceptor.js",
   "dependencies": {
     "angular": "^1.2"
-  }
+  },
+  "ignore": [
+    "package.json"
+  ]
 }


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#ignore

Because bower complains about it:
```bash
$ bower install --save angular-http-auth
bower angular-http-auth#*   not-cached git://github.com/witoldsz/angular-http-auth.git#*
bower angular-http-auth#*      resolve git://github.com/witoldsz/angular-http-auth.git#*
bower angular-http-auth#*     download https://github.com/witoldsz/angular-http-auth/archive/v1.2.2.tar.gz
bower angular-http-auth#*      extract archive.tar.gz
bower angular-http-auth#*     mismatch Version declared in the json (1.2.1) is different than the resolved one (1.2.2)
bower angular-http-auth#* invalid-meta angular-http-auth is missing "ignore" entry in bower.json
bower angular-http-auth#*     resolved git://github.com/witoldsz/angular-http-auth.git#1.2.2
bower angular-http-auth#~1.2.2 install angular-http-auth#1.2.2
```

Closes #111