### PR TITLE
Broadcast auth-loginRequired only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-http-auth",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "HTTP Auth Interceptor Module for AngularJS.",
   "main": "src/http-auth-interceptor.js",
   "repository": {

--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -48,31 +48,29 @@
    * and broadcasts 'event:auth-forbidden'.
    */
   .config(['$httpProvider', function($httpProvider) {
-    $httpProvider.interceptors.push(['$rootScope', '$q', 'httpBuffer', '$timeout',
-      function($rootScope, $q, httpBuffer, $timeout) {
-        return {
-          responseError: function(rejection) {
-            var config = rejection.config || {};
-            if (!config.ignoreAuthModule) {
-              switch (rejection.status) {
-                case 401:
-                  var deferred = $q.defer();
-                  if (httpBuffer.bufferEmpty()) {
-                    $timeout($rootScope.$broadcast('event:auth-loginRequired', rejection));
-                  }
-                  httpBuffer.append(config, deferred);
-                  return deferred.promise;
-                case 403:
-                  $rootScope.$broadcast('event:auth-forbidden', rejection);
-                  break;
-              }
+    $httpProvider.interceptors.push(['$rootScope', '$q', 'httpBuffer', '$timeout', function($rootScope, $q, httpBuffer, $timeout) {
+      return {
+        responseError: function(rejection) {
+          var config = rejection.config || {};
+          if (!config.ignoreAuthModule) {
+            switch (rejection.status) {
+              case 401:
+                var deferred = $q.defer();
+                if (httpBuffer.bufferEmpty()) {
+                  $timeout($rootScope.$broadcast('event:auth-loginRequired', rejection));
+                }
+                httpBuffer.append(config, deferred);
+                return deferred.promise;
+              case 403:
+                $rootScope.$broadcast('event:auth-forbidden', rejection);
+                break;
             }
-            // otherwise, default behaviour
-            return $q.reject(rejection);
           }
-        };
-      }
-    ]);
+          // otherwise, default behaviour
+          return $q.reject(rejection);
+        }
+      };
+    }]);
   }]);
 
   /**
@@ -131,10 +129,7 @@
         buffer = [];
       },
 
-      /**
-       * Check whether the buffer is empty
-       */
-      bufferEmpty: function() {
+      isEmpty: function() {
         return buffer.length === 0;
       }
     };

--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -56,7 +56,7 @@
             switch (rejection.status) {
               case 401:
                 var deferred = $q.defer();
-                if (httpBuffer.bufferEmpty()) {
+                if (httpBuffer.isEmpty()) {
                   $timeout($rootScope.$broadcast('event:auth-loginRequired', rejection));
                 }
                 httpBuffer.append(config, deferred);


### PR DESCRIPTION
I have encountered a bug in my angular application which uses your package. It is related to issue #95.
It occurs when using oauth refresh tokens and when multiple calls that all return HTTP 401 are fired in parallel.
The loginRequired event is then fired multiple times, which resulted in my case in multiple refresh_token calls to the oauth endpoint. All but the first call fail as a refresh_token can only be used once. When refreshing the token fails, the app falls back to showing a login form, even though the refresh token was valid and the first call obtained a valid access token.

I could have handled this case in my app by checking that I only fire one refresh_token call in the loginRequired event listener, but since I don't see a use case for emitting the loginRequired event again before loginConfirmed function was called, I thought it would be better to solve it in this library.

In issue #95 you suggest to use one probe call to avoid this issue. This solution is not adequate for my app, because waiting for this probe call would slow the app down unnecessarily in the case where the access token is still valid. This PR eliminates the need to use a probe call by only firing the loginRequired event once.

The event is now only fired if the httpBuffer is empty. If the buffer isn't empty, the the loginRequired event has already been fired, and we can safely assume that the app is in the process of logging in and will call the loginConfirmed method, emptying the buffer.

For me, the current behaviour was unexpected and maybe this change can save others from similar hard-to-reproduce bugs.
