### PR TITLE
loginConfirmed: updater returns false to ignore request

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,10 @@ The `loginConfirmed` method supports the injection of an Updater function that w
 
 The initial failed request will now be retried, all queued http requests will be recalculated using the Updater-Function.
 
+It is also possible to stop specific request from being retried, by returning ``false`` from the Updater-Function:
+
+    authService.loginConfirmed('success', function(config){
+      if (shouldSkipRetryOnSuccess(config))
+        return false;
+      return config;
+    })

--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -123,9 +123,8 @@
       retryAll: function(updater) {
         for (var i = 0; i < buffer.length; ++i) {
           var _cfg = updater(buffer[i].config);
-          if (_cfg === false)
-            continue;
-          retryHttpRequest(_cfg, buffer[i].deferred);
+          if (_cfg !== false)
+            retryHttpRequest(_cfg, buffer[i].deferred);
         }
         buffer = [];
       }

--- a/src/http-auth-interceptor.js
+++ b/src/http-auth-interceptor.js
@@ -122,7 +122,10 @@
        */
       retryAll: function(updater) {
         for (var i = 0; i < buffer.length; ++i) {
-          retryHttpRequest(updater(buffer[i].config), buffer[i].deferred);
+          var _cfg = updater(buffer[i].config);
+          if (_cfg === false)
+            continue;
+          retryHttpRequest(_cfg, buffer[i].deferred);
         }
         buffer = [];
       }


### PR DESCRIPTION
allow the request to be ignored from "retrying" when loginConfirmed's updater function returns ``false``